### PR TITLE
Avoid stack level to deep when trying to serialize the exception obje…

### DIFF
--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -135,7 +135,7 @@ module Sneakers
             "#{log_prefix} msg=failing, retry_count=#{num_attempts}, reason=#{reason}"
           end
           data = {
-            error: reason,
+            error: reason.to_s,
             num_attempts: num_attempts,
             failed_at: Time.now.iso8601,
             payload: Base64.encode64(msg.to_s),

--- a/lib/sneakers/version.rb
+++ b/lib/sneakers/version.rb
@@ -1,3 +1,3 @@
 module Sneakers
-  VERSION = "2.5.0"
+  VERSION = "2.5.1"
 end


### PR DESCRIPTION
Avoid stack level to deep when trying to serialize the exception object in maxretry handler